### PR TITLE
Implement "can_create_of_type" on the base model

### DIFF
--- a/opengever/apiclient/models/base.py
+++ b/opengever/apiclient/models/base.py
@@ -1,3 +1,5 @@
+from urllib.parse import urljoin
+
 from .registry import ModelRegistry
 
 
@@ -49,6 +51,15 @@ class APIModel:
         """
         self.update_item(self.client.fetch(raw=True))
         return self
+
+    def has_addable_type(self, content_type):
+        # Why the trailing slash?
+        # https://stackoverflow.com/a/10893427/3906189
+        types = self.client.session().get(urljoin(f'{self.url}/', '@types')).json()
+        for gever_content_type in types:
+            if gever_content_type['@id'].endswith(content_type):
+                return gever_content_type['addable']
+        return False
 
 
 @ModelRegistry.register

--- a/opengever/apiclient/models/tests/test_base.py
+++ b/opengever/apiclient/models/tests/test_base.py
@@ -35,3 +35,8 @@ class TestAPIModel(TestCase):
     def test_items(self):
         document = GEVERClient(self.document_url, self.regular_user).fetch()
         self.assertIn(document, document.parent.fetch().items)
+
+    def test_has_addable_type(self):
+        repository_folder = GEVERClient(self.repository_folder_url, self.regular_user).fetch()
+        self.assertTrue(repository_folder.has_addable_type('opengever.dossier.businesscasedossier'))
+        self.assertFalse(repository_folder.has_addable_type('opengever.repository.repositoryfolder'))


### PR DESCRIPTION
Implementation of https://plonerestapi.readthedocs.io/en/latest/types.html.
Does a request onto the `@types` endpoint and checks if a given content type can
be added.

