### PR TITLE
Implement get_navigation on GEVERClient

### DIFF
--- a/opengever/apiclient/client.py
+++ b/opengever/apiclient/client.py
@@ -45,3 +45,10 @@ class GEVERClient:
         data.update({'@type': 'opengever.dossier.businesscasedossier',
                      'title': title})
         return self.session().post(self.url, json=data).json()
+
+    def get_navigation(self, raw=False):
+        if not raw:
+            raise NotImplementedError(
+                'get_navigation currently does not support autowrapping its items, please use raw=True.'
+            )
+        return self.session().get(f'{self.url}/@navigation').json()

--- a/opengever/apiclient/tests/test_client.py
+++ b/opengever/apiclient/tests/test_client.py
@@ -1,7 +1,7 @@
-from . import TestCase
 from .. import GEVERClient
 from ..exceptions import APIRequestException
 from ..models.base import APIModel
+from . import TestCase
 
 
 class TestClient(TestCase):
@@ -50,3 +50,60 @@ class TestClient(TestCase):
         dossier = client.create_dossier('Kleines Dossier', raw=True)
         self.assertIsInstance(dossier, dict)
         self.assertEqual('Kleines Dossier', dossier['title'])
+
+    def test_get_navigation(self):
+        client = GEVERClient(self.root_url, self.regular_user)
+        with self.assertRaisesRegex(NotImplementedError, 'use raw=True'):
+            client.get_navigation()
+
+        navigation = client.get_navigation(raw=True)
+        self.assertEqual({
+            '@id': f'{self.plone_url}ordnungssystem/@navigation',
+            'tree': [
+                {
+                    '@type': 'opengever.repository.repositoryfolder',
+                    'active': True,
+                    'current': False,
+                    'current_tree': False,
+                    'description': 'Alles zum Thema Führung.',
+                    'nodes': [
+                        {
+                            '@type': 'opengever.repository.repositoryfolder',
+                            'active': True,
+                            'current': False,
+                            'current_tree': False,
+                            'description': '',
+                            'nodes': [],
+                            'text': '1.1. Verträge und Vereinbarungen',
+                            'uid': 'createrepositorytree000000000003',
+                            'url': f'{self.plone_url}ordnungssystem/fuehrung/vertraege-und-vereinbarungen',
+                        }
+                    ],
+                    'text': '1. Führung',
+                    'uid': 'createrepositorytree000000000002',
+                    'url': f'{self.plone_url}ordnungssystem/fuehrung',
+                },
+                {
+                    '@type': 'opengever.repository.repositoryfolder',
+                    'active': True,
+                    'current': False,
+                    'current_tree': False,
+                    'description': '',
+                    'nodes': [],
+                    'text': '2. Rechnungsprüfungskommission',
+                    'uid': 'createrepositorytree000000000004',
+                    'url': f'{self.plone_url}ordnungssystem/rechnungspruefungskommission',
+                },
+                {
+                    '@type': 'opengever.repository.repositoryfolder',
+                    'active': False,
+                    'current': False,
+                    'current_tree': False,
+                    'description': '',
+                    'nodes': [],
+                    'text': '3. Spinnännetzregistrar',
+                    'uid': 'createrepositorytree000000000005',
+                    'url': f'{self.plone_url}ordnungssystem/spinnaennetzregistrar',
+                },
+            ],
+        }, navigation)


### PR DESCRIPTION
To be able to get the navigation of a GEVER, I introduce a new method called
"get_navigation", which lets you get the navigation of a given position in
GEVER but also on the root.

To ensure we have the same defaults `raw=False` as on every other method which
the apiclient exposes (done by the `@autowrap` decorator), I implemented the
method in the same manner.