### PR TITLE
Include original response from GEVER when raising exceptions

### DIFF
--- a/opengever/apiclient/exceptions.py
+++ b/opengever/apiclient/exceptions.py
@@ -58,7 +58,7 @@ class APIRequestException(APIException):
         if self.original_exception:
             msgs.append(f"Original exception: {self.original_exception}.")
 
-            if self.original_exception.response and self.original_exception.response.text:
+            if hasattr(self.original_exception, "response") and self.original_exception.response.text:
                 msgs.append(f"Response from GEVER: {self.original_exception.response.text}")
 
         LOG.error("\n".join(msgs))

--- a/opengever/apiclient/tests/test_client.py
+++ b/opengever/apiclient/tests/test_client.py
@@ -1,4 +1,5 @@
 import re
+import requests_mock
 
 from .. import GEVERClient
 from ..exceptions import APIRequestException
@@ -38,6 +39,17 @@ class TestClient(TestCase):
         self.assertEqual(
             f'404 Client Error: Not Found for url: {self.plone_url}ordnungssystem/bad-url',
             str(cm.exception))
+
+    def test_exception_includes_response_from_gever(self):
+        client = GEVERClient(f'{self.plone_url}ordnungssystem/nope', self.regular_user)
+        with requests_mock.Mocker() as mocker:
+            mocker.get(f'{self.plone_url}ordnungssystem/nope', text='GEVER says no', status_code=500)
+            with self.assertLogs(level='ERROR') as cm, self.assertRaises(APIRequestException):
+                client.fetch()
+
+        # The last error should include the original response from GEVER.
+        error = cm.output[-1]
+        self.assertIn('Response from GEVER: GEVER says no', error)
 
     def test_create_dossier(self):
         client = GEVERClient(self.repository_folder_url, self.regular_user)

--- a/opengever/apiclient/tests/test_client.py
+++ b/opengever/apiclient/tests/test_client.py
@@ -1,4 +1,3 @@
-import re
 import requests_mock
 
 from .. import GEVERClient


### PR DESCRIPTION
`bool(Response)` returns False if the Response was not successful (see https://github.com/psf/requests/blob/master/requests/models.py#L673-L681). Therefore the original response text from GEVER was never added to the logged messages.

Adding the response from GEVER helps when during debugging.