### PR TITLE
Remove the GEVER team from the GitHub code owners.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @4teamwork/django @4teamwork/gever
+*       @4teamwork/django


### PR DESCRIPTION
This has been decided at a round table between the Django, GEVER and software architecture teams.