### PR TITLE
Log errors as exception to include the stack trace.

### DIFF
--- a/opengever/apiclient/exceptions.py
+++ b/opengever/apiclient/exceptions.py
@@ -61,7 +61,7 @@ class APIRequestException(APIException):
             if hasattr(self.original_exception, "response") and self.original_exception.response.text:
                 msgs.append(f"Response from GEVER: {self.original_exception.response.text}")
 
-        LOG.error("\n".join(msgs))
+        LOG.exception("\n".join(msgs))
 
     @classmethod
     def emit_log(cls, exception):


### PR DESCRIPTION
Logging errors as exception includes the stack trace in Sentry, which is helpful for debugging.

See https://github.com/4teamwork/ris/pull/1760.