### PR TITLE
Accept headers on constructor for requests session

### DIFF
--- a/opengever/apiclient/client.py
+++ b/opengever/apiclient/client.py
@@ -10,7 +10,7 @@ class GEVERClient:
     It is instantiated for a specific GEVER resource in the name of a specific user.
     """
 
-    def __init__(self, url, username):
+    def __init__(self, url, username, headers={}):
         """
         :param url: The base URL to a resource in GEVER without the view.
         :type url: string
@@ -20,7 +20,7 @@ class GEVERClient:
         """
         self.url = url.rstrip("/")  # Remove trailing slash(es).
         self.username = username
-        self.session = GEVERSession(url, username)
+        self.session = GEVERSession(url, username, headers)
 
     def adopt(self, url):
         """Create and return a new GEVERClient instance for the passed url.

--- a/opengever/apiclient/session.py
+++ b/opengever/apiclient/session.py
@@ -32,12 +32,13 @@ class GEVERSession:
     min_seconds_to_expiration = 60
     session_expiration_seconds = 60 * 60
 
-    def __init__(self, url, username):
+    def __init__(self, url, username, headers={}):
         self.gever_base_url = KeyRegistry.get_base_url_for(url)
         if not self.gever_base_url:
             raise ServiceKeyMissing(url)
 
         self.username = username
+        self.headers = headers
         self._session = self._get_session()
 
     def __call__(self):
@@ -79,8 +80,13 @@ class GEVERSession:
         """
         session = requests.Session()
         session.hooks["response"].append(self._raise_for_status_hook)
-        session.headers.update({"User-Agent": self._user_agent})
-        session.headers.update({"Accept": "application/json"})
+        session.headers.update(
+            {
+                "User-Agent": self._user_agent,
+                "Accept": "application/json",
+                **self.headers,
+            }
+        )
         self._acquire_authorization_token(session)
         return session
 

--- a/opengever/apiclient/tests/test_client.py
+++ b/opengever/apiclient/tests/test_client.py
@@ -195,3 +195,7 @@ class TestClient(TestCase):
             'filename': 'Ein Dokument.txt',
             'size': 23
         }, document.file)
+
+    def test_accepts_headers(self):
+        client = GEVERClient(url=self.dossier_url, username=self.regular_user, headers={'Accept-Language': 'fr-CH'})
+        self.assertDictContainsSubset({'Accept-Language': 'fr-CH'}, client.session.headers)


### PR DESCRIPTION
As https://github.com/4teamwork/vertragsmanagement/issues/88 requires, it must be possible to fetch GEVER with an `Accept-Language` header.