### PR TITLE
Allow to set other roles than the default plone roles.

### DIFF
--- a/opengever/apiclient/client.py
+++ b/opengever/apiclient/client.py
@@ -131,7 +131,7 @@ class GEVERClient:
     def sharing(self):
         return self.session().get(f'{self.url}/@sharing').json()
 
-    def add_sharing_group(self, name, is_contributor=False, is_editor=False, is_reader=False, is_reviewer=False):
+    def set_group_roles(self, name, roles):
         """
         https://plonerestapi.readthedocs.io/en/latest/sharing.html#updating-local-roles
         """
@@ -139,17 +139,10 @@ class GEVERClient:
             "entries": [
                 {
                     "id": name,
-                    "title": name,
                     "type": "group",
-                    "roles": {
-                        "Contributor": is_contributor,
-                        "Editor": is_editor,
-                        "Reader": is_reader,
-                        "Reviewer": is_reviewer
-                    },
+                    "roles": roles
                 }
             ],
-            "inherit": True
         }
         response = self.session().post(f'{self.url}/@sharing', json=data)
         return response.ok

--- a/opengever/apiclient/tests/test_client.py
+++ b/opengever/apiclient/tests/test_client.py
@@ -213,7 +213,7 @@ class TestClient(TestCase):
     def test_set_sharing(self):
         sharing = GEVERClient(url=self.dossier_url, username='nicole.kohler').sharing()
         self.assertNotIn('rk_users', [entry['id'] for entry in sharing['entries']])
-        ok = GEVERClient(url=self.dossier_url, username='nicole.kohler').add_sharing_group('rk_users', is_reader=True)
+        ok = GEVERClient(url=self.dossier_url, username='nicole.kohler').set_group_roles('rk_users', {'Reader': True})
         self.assertTrue(ok)
         sharing = GEVERClient(url=self.dossier_url, username='nicole.kohler').sharing()
         self.assertIn('rk_users', [entry['id'] for entry in sharing['entries']])


### PR DESCRIPTION
With this PR it becomes possible to set other roles than the ones chosen here. This means that other existing roles will no longer be overwritten. Furthermore, `blocked_local_roles` will also no longer be overwritten.

Jira: https://4teamwork.atlassian.net/browse/NE-640