### PR TITLE
Get user from @users with userid from @ogds-users

### DIFF
--- a/opengever/apiclient/client.py
+++ b/opengever/apiclient/client.py
@@ -91,6 +91,9 @@ class GEVERClient:
             .json()['allowed_roles_and_principals']
         )
 
+    def ogds_user(self):
+        return self.session().get(f'{self.url}/@ogds-users/{self.username}').json()
+
     def user(self):
         return self.session().get(f'{self.url}/@users/{self.username}').json()
 

--- a/opengever/apiclient/client.py
+++ b/opengever/apiclient/client.py
@@ -95,7 +95,8 @@ class GEVERClient:
         return self.session().get(f'{self.url}/@ogds-users/{self.username}').json()
 
     def user(self):
-        return self.session().get(f'{self.url}/@users/{self.username}').json()
+        userid = self.ogds_user()['userid']
+        return self.session().get(f'{self.url}/@users/{userid}').json()
 
     @autowrap
     def create_document(self, title, file, content_type, filename, size=None):


### PR DESCRIPTION
The @users endpoint no longer works with the username, so we must first 
retrieve the userid and then the user from the @users endpoint.